### PR TITLE
Printstream.cpp: Don't flush when 'ArduinoFake' is defined

### DIFF
--- a/src/AH/PrintStream/PrintStream.cpp
+++ b/src/AH/PrintStream/PrintStream.cpp
@@ -5,7 +5,7 @@
 // LCOV_EXCL_START
 
 #if not defined(ARDUINO_ARCH_ESP32) && not defined(ARDUINO_ARCH_SAM) &&        \
-    not defined(ARDUINO_API_VERSION)
+    not defined(ARDUINO_API_VERSION) && not defined(ArduinoFake)
 #define FLUSH
 #endif
 


### PR DESCRIPTION
Hi!

Great library, high quality stuff going on here :)

The mocking library [ArduinoFake](https://github.com/FabioBatSilva/ArduinoFake) doesnt provide a flush for their mock printer. This add an exclusion for ArduinoFake so that on native builds (mostly for unittests) succeed. 

Of course, the same can be achieved with macro's, but then I'd end up littering #ifndef's all over the place where I'd use your great library. Likewise, adding a flush to the ArduinoFake lib would make their's more brittle.

Greetings (gegroet?), Stan